### PR TITLE
fix: makeGitHooksExecutable 수정 (#10)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,13 @@ tasks.register('updateGitHooks', Copy) {
 }
 
 tasks.register('makeGitHooksExecutable', Exec) {
-	commandLine 'chmod', '+x', './.git/hooks/pre-commit'
+	if (System.getProperty("os.name").toLowerCase().contains('win')) {
+		// Windows에서는 icacls 실행
+		commandLine 'cmd', '/c', 'icacls', '.git\\hooks\\pre-commit', '/grant', 'Everyone:(R,W)'
+	} else {
+		// Linux/macOS에서는 chmod 실행
+		commandLine 'chmod', '+x', './.git/hooks/pre-commit'
+	}
 	dependsOn updateGitHooks
 }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- close #10 

---
## 📌 작업 내용 및 특이사항

- Window os의 경우 'chmod' 명령어를 사용할 수 없어 수정
- 사용하지 않는 import문을 추가해서 pre-commit 스크립트가 해당 import문을 제거하는 지 테스트
- 스크립트 동작 확인, 추후 문제될 시 재확인 필요

---
## 📚 참고사항

-
