### PR TITLE
feat: 로그아웃 · 회원탈퇴 · 회원정보 수정 기능

### DIFF
--- a/src/main/java/com/amcamp/cineAI/domain/auth/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/amcamp/cineAI/domain/auth/dao/RefreshTokenRepository.java
@@ -1,8 +1,10 @@
 package com.amcamp.cineAI.domain.auth.dao;
 
 import com.amcamp.cineAI.domain.auth.domain.RefreshToken;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     RefreshToken findByToken(String token);
+
+    <Optional> RefreshToken findByMemberId(Long memberId);
 }

--- a/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
@@ -6,10 +6,7 @@ import com.amcamp.cineAI.global.util.CookieUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "회원 API", description = "회원 관련 API입니다.")
 @RestController
@@ -19,6 +16,12 @@ public class MemberController {
 
     private final CookieUtil cookieUtil;
     private final MemberService memberService;
+
+    @DeleteMapping("/withdrawal")
+    public ResponseEntity<Void> memberWithdrawal() {
+        memberService.withdrawalMember();
+        return ResponseEntity.ok().headers(cookieUtil.deleteRefreshTokenCookie()).build();
+    }
 
     @PostMapping("/logout")
     public ResponseEntity<Void> memberLogout() {

--- a/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
@@ -1,9 +1,11 @@
 package com.amcamp.cineAI.domain.member.api;
 
 import com.amcamp.cineAI.domain.member.application.MemberService;
+import com.amcamp.cineAI.domain.member.dto.request.MemberEditRequest;
 import com.amcamp.cineAI.domain.member.dto.response.MemberInfoResponse;
 import com.amcamp.cineAI.global.util.CookieUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -32,5 +34,12 @@ public class MemberController {
     @GetMapping("/me")
     public MemberInfoResponse memberInfo() {
         return memberService.getMemberInfo();
+    }
+
+    @PatchMapping("/me/edit")
+    public ResponseEntity<Void> memberEdit(
+            @Valid @RequestBody MemberEditRequest memberEditRequest) {
+        memberService.editMemberInfo(memberEditRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
@@ -5,7 +5,9 @@ import com.amcamp.cineAI.domain.member.dto.response.MemberInfoResponse;
 import com.amcamp.cineAI.global.util.CookieUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +19,12 @@ public class MemberController {
 
     private final CookieUtil cookieUtil;
     private final MemberService memberService;
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> memberLogout() {
+        memberService.logoutMember();
+        return ResponseEntity.ok().headers(cookieUtil.deleteRefreshTokenCookie()).build();
+    }
 
     @GetMapping("/me")
     public MemberInfoResponse memberInfo() {

--- a/src/main/java/com/amcamp/cineAI/domain/member/application/MemberService.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/application/MemberService.java
@@ -1,5 +1,7 @@
 package com.amcamp.cineAI.domain.member.application;
 
+import com.amcamp.cineAI.domain.auth.dao.RefreshTokenRepository;
+import com.amcamp.cineAI.domain.auth.domain.RefreshToken;
 import com.amcamp.cineAI.domain.member.domain.Member;
 import com.amcamp.cineAI.domain.member.dto.response.MemberInfoResponse;
 import com.amcamp.cineAI.global.util.MemberUtil;
@@ -12,6 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberUtil memberUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public void logoutMember() {
+        Member currentMember = memberUtil.getCurrentMember();
+        RefreshToken refreshToken = refreshTokenRepository.findByMemberId(currentMember.getId());
+        refreshTokenRepository.delete(refreshToken);
+    }
 
     @Transactional(readOnly = true)
     public MemberInfoResponse getMemberInfo() {

--- a/src/main/java/com/amcamp/cineAI/domain/member/application/MemberService.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/application/MemberService.java
@@ -2,7 +2,9 @@ package com.amcamp.cineAI.domain.member.application;
 
 import com.amcamp.cineAI.domain.auth.dao.RefreshTokenRepository;
 import com.amcamp.cineAI.domain.auth.domain.RefreshToken;
+import com.amcamp.cineAI.domain.member.dao.MemberRepository;
 import com.amcamp.cineAI.domain.member.domain.Member;
+import com.amcamp.cineAI.domain.member.dto.request.MemberEditRequest;
 import com.amcamp.cineAI.domain.member.dto.response.MemberInfoResponse;
 import com.amcamp.cineAI.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
     private final MemberUtil memberUtil;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberRepository memberRepository;
 
     public void logoutMember() {
         Member currentMember = memberUtil.getCurrentMember();
@@ -34,6 +37,12 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberInfoResponse getMemberInfo() {
         Member currentMember = memberUtil.getCurrentMember();
+        return MemberInfoResponse.of(currentMember);
+    }
+
+    public MemberInfoResponse editMemberInfo(MemberEditRequest memberEditRequest) {
+        Member currentMember = memberUtil.getCurrentMember();
+        currentMember.updateNickname(memberEditRequest.nickname());
         return MemberInfoResponse.of(currentMember);
     }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/member/application/MemberService.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/application/MemberService.java
@@ -22,6 +22,15 @@ public class MemberService {
         refreshTokenRepository.delete(refreshToken);
     }
 
+    public void withdrawalMember() {
+        Member currentMember = memberUtil.getCurrentMember();
+        refreshTokenRepository
+                .findById(currentMember.getId())
+                .ifPresent(refreshTokenRepository::delete);
+
+        currentMember.withdrawal();
+    }
+
     @Transactional(readOnly = true)
     public MemberInfoResponse getMemberInfo() {
         Member currentMember = memberUtil.getCurrentMember();

--- a/src/main/java/com/amcamp/cineAI/domain/member/domain/Member.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/domain/Member.java
@@ -62,4 +62,8 @@ public class Member {
         }
         this.status = MemberStatus.DELETED;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/member/domain/Member.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/domain/Member.java
@@ -1,5 +1,7 @@
 package com.amcamp.cineAI.domain.member.domain;
 
+import com.amcamp.cineAI.global.error.exception.CustomException;
+import com.amcamp.cineAI.global.error.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -52,5 +54,12 @@ public class Member {
 
     public void reEnroll() {
         this.status = MemberStatus.NORMAL;
+    }
+
+    public void withdrawal() {
+        if (this.status == MemberStatus.DELETED) {
+            throw new CustomException(ErrorCode.MEMBER_ALREADY_DELETED);
+        }
+        this.status = MemberStatus.DELETED;
     }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/member/dto/request/MemberEditRequest.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/dto/request/MemberEditRequest.java
@@ -1,0 +1,5 @@
+package com.amcamp.cineAI.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberEditRequest(@NotBlank(message = "닉네임은 비워둘 수 없습니다.") String nickname) {}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #21 

---
## 📌 작업 내용 및 특이사항

- 로그아웃 기능 구현: 전송 시 리프레시 토큰 정보가 삭제됩니다.
- 회원탈퇴 기능 구현: 전송 시 리프레시 토큰 정보가 삭제되며 회원 상태도 "DELETED"로 변경됩니다.
- 회원정보 수정 기능 구현: 닉네임이 변경됩니다. 

---
## 📚 참고사항

-
