### PR TITLE
feat: 최신 영화 추가, 최신 영화 목록 조회, 영화 상세 정보 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,14 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	// Spring WebFlux 의존성 추가
+	// Spring WebFlux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 }
 
@@ -91,3 +97,14 @@ tasks.register('makeGitHooksExecutable', Exec) {
 }
 
 compileJava.dependsOn makeGitHooksExecutable
+
+// Q타입 엔티티가 생성될 경로
+def querydslSrcDir = 'src/main/generated'
+// clean 시 Q타입 삭제
+clean {
+	delete file(querydslSrcDir)
+}
+// compile시 Q타입 경로에 파일 생성
+tasks.withType(JavaCompile).configureEach {
+	options.generatedSourceOutputDirectory = file(querydslSrcDir)
+}

--- a/src/main/generated/com/amcamp/cineAI/domain/auth/domain/QRefreshToken.java
+++ b/src/main/generated/com/amcamp/cineAI/domain/auth/domain/QRefreshToken.java
@@ -1,0 +1,41 @@
+package com.amcamp.cineAI.domain.auth.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QRefreshToken is a Querydsl query type for RefreshToken
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRefreshToken extends EntityPathBase<RefreshToken> {
+
+    private static final long serialVersionUID = 403417047L;
+
+    public static final QRefreshToken refreshToken = new QRefreshToken("refreshToken");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Long> memberId = createNumber("memberId", Long.class);
+
+    public final StringPath token = createString("token");
+
+    public QRefreshToken(String variable) {
+        super(RefreshToken.class, forVariable(variable));
+    }
+
+    public QRefreshToken(Path<? extends RefreshToken> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QRefreshToken(PathMetadata metadata) {
+        super(RefreshToken.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/amcamp/cineAI/domain/common/model/QBaseTimeEntity.java
+++ b/src/main/generated/com/amcamp/cineAI/domain/common/model/QBaseTimeEntity.java
@@ -1,0 +1,39 @@
+package com.amcamp.cineAI.domain.common.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTimeEntity is a Querydsl query type for BaseTimeEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTimeEntity extends EntityPathBase<BaseTimeEntity> {
+
+    private static final long serialVersionUID = -1318249452L;
+
+    public static final QBaseTimeEntity baseTimeEntity = new QBaseTimeEntity("baseTimeEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdDt = createDateTime("createdDt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedDt = createDateTime("updatedDt", java.time.LocalDateTime.class);
+
+    public QBaseTimeEntity(String variable) {
+        super(BaseTimeEntity.class, forVariable(variable));
+    }
+
+    public QBaseTimeEntity(Path<? extends BaseTimeEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTimeEntity(PathMetadata metadata) {
+        super(BaseTimeEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/amcamp/cineAI/domain/member/domain/QMember.java
+++ b/src/main/generated/com/amcamp/cineAI/domain/member/domain/QMember.java
@@ -1,0 +1,47 @@
+package com.amcamp.cineAI.domain.member.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = -1981346427L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath profileImageUrl = createString("profileImageUrl");
+
+    public final EnumPath<MemberRole> role = createEnum("role", MemberRole.class);
+
+    public final EnumPath<MemberStatus> status = createEnum("status", MemberStatus.class);
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/amcamp/cineAI/domain/movie/domain/QMovie.java
+++ b/src/main/generated/com/amcamp/cineAI/domain/movie/domain/QMovie.java
@@ -1,0 +1,65 @@
+package com.amcamp.cineAI.domain.movie.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMovie is a Querydsl query type for Movie
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMovie extends EntityPathBase<Movie> {
+
+    private static final long serialVersionUID = 1903323993L;
+
+    public static final QMovie movie = new QMovie("movie");
+
+    public final com.amcamp.cineAI.domain.common.model.QBaseTimeEntity _super = new com.amcamp.cineAI.domain.common.model.QBaseTimeEntity(this);
+
+    public final NumberPath<Long> accAudiences = createNumber("accAudiences", Long.class);
+
+    public final ArrayPath<String[], String> castsList = createArray("castsList", String[].class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdDt = _super.createdDt;
+
+    public final StringPath directorName = createString("directorName");
+
+    public final ArrayPath<String[], String> genreList = createArray("genreList", String[].class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath nation = createString("nation");
+
+    public final StringPath plot = createString("plot");
+
+    public final StringPath posterImageUrl = createString("posterImageUrl");
+
+    public final StringPath releaseYear = createString("releaseYear");
+
+    public final EnumPath<MovieStatus> status = createEnum("status", MovieStatus.class);
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedDt = _super.updatedDt;
+
+    public QMovie(String variable) {
+        super(Movie.class, forVariable(variable));
+    }
+
+    public QMovie(Path<? extends Movie> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMovie(PathMetadata metadata) {
+        super(Movie.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/amcamp/cineAI/domain/common/model/BaseTimeEntity.java
+++ b/src/main/java/com/amcamp/cineAI/domain/common/model/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.amcamp.cineAI.domain.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDt;
+
+    @LastModifiedDate private LocalDateTime updatedDt;
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
@@ -1,0 +1,46 @@
+package com.amcamp.cineAI.domain.movie.api;
+
+import com.amcamp.cineAI.domain.movie.application.MovieService;
+import com.amcamp.cineAI.domain.movie.dto.request.NewMovieCreateRequest;
+import com.amcamp.cineAI.domain.movie.dto.response.BasicMovieInfoResponse;
+import com.amcamp.cineAI.domain.movie.dto.response.MovieInfoResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "영화 API", description = "영화 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/movies")
+public class MovieController {
+
+    private final MovieService movieService;
+
+    @Operation(summary = "최신 영화 추가", description = "최신 영화를 추가합니다.")
+    @PostMapping("/create")
+    public ResponseEntity<Void> movieCreate(@Valid @RequestBody NewMovieCreateRequest request) {
+        movieService.createMovie(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "최신 영화 목록 조회", description = "등록된 최신 영화 정보를 조회합니다.")
+    @GetMapping("/new-movies")
+    public Slice<BasicMovieInfoResponse> newMovieList(
+            @Parameter(description = "이전 페이지의 마지막 영화 ID (첫 페이지는 비워두세요)")
+                    @RequestParam(required = false)
+                    Long lastMovieId,
+            @RequestParam(value = "size", defaultValue = "3") int pageSize) {
+        return movieService.getNewMovieList(lastMovieId, pageSize);
+    }
+
+    @Operation(summary = "영화 상세 조회", description = "등록된 최신 영화 정보를 조회합니다.")
+    @GetMapping("/{movieId}")
+    public MovieInfoResponse movieInfo(@PathVariable Long movieId) {
+        return movieService.getMovieInfo(movieId);
+    }
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/application/MovieService.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/application/MovieService.java
@@ -1,0 +1,39 @@
+package com.amcamp.cineAI.domain.movie.application;
+
+import com.amcamp.cineAI.domain.movie.dao.MovieRepository;
+import com.amcamp.cineAI.domain.movie.domain.Movie;
+import com.amcamp.cineAI.domain.movie.dto.request.NewMovieCreateRequest;
+import com.amcamp.cineAI.domain.movie.dto.response.BasicMovieInfoResponse;
+import com.amcamp.cineAI.domain.movie.dto.response.MovieInfoResponse;
+import com.amcamp.cineAI.global.error.exception.CustomException;
+import com.amcamp.cineAI.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class MovieService {
+    private final MovieRepository movieRepository;
+
+    public void createMovie(NewMovieCreateRequest request) {
+        Movie newMovie = Movie.createMovie(request);
+        movieRepository.save(newMovie);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<BasicMovieInfoResponse> getNewMovieList(Long lastMovieId, int pageSize) {
+        return movieRepository.findAllNewMovie(lastMovieId, pageSize);
+    }
+
+    @Transactional(readOnly = true)
+    public MovieInfoResponse getMovieInfo(Long movieId) {
+        Movie movie =
+                movieRepository
+                        .findById(movieId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.MOVIE_NOT_FOUND)); // 예외 던짐
+        return MovieInfoResponse.of(movie);
+    }
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dao/MovieRepository.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dao/MovieRepository.java
@@ -1,0 +1,6 @@
+package com.amcamp.cineAI.domain.movie.dao;
+
+import com.amcamp.cineAI.domain.movie.domain.Movie;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MovieRepository extends JpaRepository<Movie, Long>, MovieRepositoryCustom {}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dao/MovieRepositoryCustom.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dao/MovieRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.amcamp.cineAI.domain.movie.dao;
+
+import com.amcamp.cineAI.domain.movie.dto.response.BasicMovieInfoResponse;
+import org.springframework.data.domain.Slice;
+
+public interface MovieRepositoryCustom {
+    Slice<BasicMovieInfoResponse> findAllNewMovie(Long lastMovieId, int pageSize);
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dao/MovieRepositoryImpl.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dao/MovieRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.amcamp.cineAI.domain.movie.dao;
+
+import static com.amcamp.cineAI.domain.movie.domain.QMovie.movie;
+
+import com.amcamp.cineAI.domain.movie.domain.MovieStatus;
+import com.amcamp.cineAI.domain.movie.dto.response.BasicMovieInfoResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MovieRepositoryImpl implements MovieRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Slice<BasicMovieInfoResponse> findAllNewMovie(Long lastMovieId, int pageSize) {
+        List<BasicMovieInfoResponse> results =
+                jpaQueryFactory
+                        .select(
+                                Projections.constructor(
+                                        BasicMovieInfoResponse.class,
+                                        movie.title,
+                                        movie.posterImageUrl,
+                                        movie.genreList,
+                                        movie.releaseYear))
+                        .from(movie)
+                        .where(movie.status.eq(MovieStatus.CREATED))
+                        .orderBy(movie.createdDt.desc())
+                        .limit(pageSize + 1)
+                        .fetch();
+        return checkLastPage(pageSize, results);
+    }
+
+    private BooleanExpression lastMemberId(Long movieId) {
+        if (movieId == null) {
+            return null;
+        }
+
+        return movie.id.lt(movieId);
+    }
+
+    private Slice<BasicMovieInfoResponse> checkLastPage(
+            int pageSize, List<BasicMovieInfoResponse> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+    }
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/domain/Movie.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/domain/Movie.java
@@ -1,0 +1,71 @@
+package com.amcamp.cineAI.domain.movie.domain;
+
+import com.amcamp.cineAI.domain.common.model.BaseTimeEntity;
+import com.amcamp.cineAI.domain.movie.dto.request.NewMovieCreateRequest;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Movie extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "movie_id")
+    private Long id;
+
+    private String title;
+    private String posterImageUrl;
+    private String directorName;
+    private String[] castsList;
+    private String nation;
+    private String plot;
+    private String[] genreList;
+    private Long accAudiences;
+    private String releaseYear;
+
+    @Enumerated(EnumType.STRING)
+    private MovieStatus status;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Movie(
+            String title,
+            String posterImageUrl,
+            String directorName,
+            String nation,
+            String[] castList,
+            String plot,
+            String[] genreList,
+            Long accAudiences,
+            String releaseYear,
+            MovieStatus status) {
+        this.title = title;
+        this.posterImageUrl = posterImageUrl;
+        this.directorName = directorName;
+        this.castsList = castList;
+        this.nation = nation;
+        this.plot = plot;
+        this.genreList = genreList;
+        this.accAudiences = accAudiences;
+        this.releaseYear = releaseYear;
+        this.status = status;
+    }
+
+    public static Movie createMovie(NewMovieCreateRequest request) {
+        return Movie.builder()
+                .title(request.title())
+                .posterImageUrl(request.posterImageUrl())
+                .directorName(request.directorName())
+                .castList(request.castList())
+                .nation(request.nation())
+                .plot(request.plot())
+                .genreList(request.genreList())
+                .accAudiences(request.accAudiences())
+                .releaseYear(request.releaseYear())
+                .status(MovieStatus.CREATED)
+                .build();
+    }
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/domain/MovieStatus.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/domain/MovieStatus.java
@@ -1,0 +1,12 @@
+package com.amcamp.cineAI.domain.movie.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MovieStatus {
+    NORMAL("NORMAL"),
+    CREATED("CREATED");
+    private final String role;
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dto/request/NewMovieCreateRequest.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dto/request/NewMovieCreateRequest.java
@@ -1,0 +1,12 @@
+package com.amcamp.cineAI.domain.movie.dto.request;
+
+public record NewMovieCreateRequest(
+        String title,
+        String posterImageUrl,
+        String directorName,
+        String[] castList,
+        String nation,
+        String plot,
+        String[] genreList,
+        Long accAudiences,
+        String releaseYear) {}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dto/response/BasicMovieInfoResponse.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dto/response/BasicMovieInfoResponse.java
@@ -1,0 +1,4 @@
+package com.amcamp.cineAI.domain.movie.dto.response;
+
+public record BasicMovieInfoResponse(
+        String title, String posterImageUrl, String[] genreList, String releaseYear) {}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dto/response/MovieInfoResponse.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dto/response/MovieInfoResponse.java
@@ -1,0 +1,29 @@
+package com.amcamp.cineAI.domain.movie.dto.response;
+
+import com.amcamp.cineAI.domain.movie.domain.Movie;
+
+public record MovieInfoResponse(
+        Long id,
+        String title,
+        String posterImageUrl,
+        String directorName,
+        String[] castsList,
+        String nation,
+        String plot,
+        String[] genreList,
+        Long accAudiences,
+        String releaseYear) {
+    public static MovieInfoResponse of(Movie movie) {
+        return new MovieInfoResponse(
+                movie.getId(),
+                movie.getTitle(),
+                movie.getPosterImageUrl(),
+                movie.getDirectorName(),
+                movie.getCastsList(),
+                movie.getNation(),
+                movie.getPlot(),
+                movie.getGenreList(),
+                movie.getAccAudiences(),
+                movie.getReleaseYear());
+    }
+}

--- a/src/main/java/com/amcamp/cineAI/global/config/jpa/JPAConfig.java
+++ b/src/main/java/com/amcamp/cineAI/global/config/jpa/JPAConfig.java
@@ -1,0 +1,19 @@
+package com.amcamp.cineAI.global.config.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JPAConfig {
+    @PersistenceContext private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/amcamp/cineAI/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/amcamp/cineAI/global/error/exception/ErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
     MEMBER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
-    AUTH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "사용자 인증 정보를 찾을 수 없습니다. 올바른 토큰으로 요청해주세요.");
+    AUTH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "사용자 인증 정보를 찾을 수 없습니다. 올바른 토큰으로 요청해주세요."),
+    MOVIE_NOT_FOUND(HttpStatus.NOT_FOUND, "영화를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/amcamp/cineAI/global/util/MemberUtil.java
+++ b/src/main/java/com/amcamp/cineAI/global/util/MemberUtil.java
@@ -21,7 +21,6 @@ public class MemberUtil {
                 memberRepository
                         .findById(getCurrentMemberId())
                         .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
         if (member.getStatus() == MemberStatus.DELETED) {
             throw new CustomException(ErrorCode.MEMBER_ALREADY_DELETED);
         }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #27 

---
## 📌 작업 내용 및 특이사항

- 최신 영화 업로드 기능, 최신 영화 목록 조회 기능, 영화 상세 정보 조회 기능을 구현했습니다.
- 최신 영화 목록 조회는 FE에서 페이징 처리할 수 있게 QueryDSL로 구현하였습니다.
- KMDB에서 가져온 영화 상태는 NORMAL, 직접 생성한 영화의 상태는 CREATED로 저장됩니다.
- 최신 영화 목록 조회 시 BaseTimeEntity를 상속받아 생성일자 내림차순으로 조회할 수 있게 구현하였습니다. 

---
## 📚 참고사항

- https://velog.io/@dnjsdn96/JPAQueryDSL-QueryDSL-세팅하기
