### PR TITLE
feat: 초기 영화 목록 조회 · 영화 선호도 업데이트 · 회원 선호 영화 목록 조회 기능 구현 

### DIFF
--- a/src/main/generated/com/amcamp/cineAI/domain/movie/domain/QMovie.java
+++ b/src/main/generated/com/amcamp/cineAI/domain/movie/domain/QMovie.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.PathMetadata;
 import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
@@ -23,14 +24,14 @@ public class QMovie extends EntityPathBase<Movie> {
 
     public final NumberPath<Long> accAudiences = createNumber("accAudiences", Long.class);
 
-    public final ArrayPath<String[], String> castsList = createArray("castsList", String[].class);
+    public final ListPath<String, StringPath> castsList = this.<String, StringPath>createList("castsList", String.class, StringPath.class, PathInits.DIRECT2);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdDt = _super.createdDt;
 
     public final StringPath directorName = createString("directorName");
 
-    public final ArrayPath<String[], String> genreList = createArray("genreList", String[].class);
+    public final ListPath<String, StringPath> genreList = this.<String, StringPath>createList("genreList", String.class, StringPath.class, PathInits.DIRECT2);
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 

--- a/src/main/generated/com/amcamp/cineAI/domain/movie/domain/QMoviePreference.java
+++ b/src/main/generated/com/amcamp/cineAI/domain/movie/domain/QMoviePreference.java
@@ -1,0 +1,64 @@
+package com.amcamp.cineAI.domain.movie.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMoviePreference is a Querydsl query type for MoviePreference
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMoviePreference extends EntityPathBase<MoviePreference> {
+
+    private static final long serialVersionUID = 1157196052L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMoviePreference moviePreference = new QMoviePreference("moviePreference");
+
+    public final com.amcamp.cineAI.domain.common.model.QBaseTimeEntity _super = new com.amcamp.cineAI.domain.common.model.QBaseTimeEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdDt = _super.createdDt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<MovieLikedStatus> liked = createEnum("liked", MovieLikedStatus.class);
+
+    public final com.amcamp.cineAI.domain.member.domain.QMember member;
+
+    public final QMovie movie;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedDt = _super.updatedDt;
+
+    public QMoviePreference(String variable) {
+        this(MoviePreference.class, forVariable(variable), INITS);
+    }
+
+    public QMoviePreference(Path<? extends MoviePreference> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMoviePreference(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMoviePreference(PathMetadata metadata, PathInits inits) {
+        this(MoviePreference.class, metadata, inits);
+    }
+
+    public QMoviePreference(Class<? extends MoviePreference> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.amcamp.cineAI.domain.member.domain.QMember(forProperty("member")) : null;
+        this.movie = inits.isInitialized("movie") ? new QMovie(forProperty("movie")) : null;
+    }
+
+}
+

--- a/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
@@ -58,6 +58,7 @@ public class MemberController {
                     Long lastMovieId,
             @RequestParam(value = "size", defaultValue = "3") int pageSize) {
         return memberService.getMemberLikedMovie(lastMovieId, pageSize);
+    }
 
     @Operation(summary = "관리자 로그인", description = "관리자용 비밀번호를 입력받아 관리자 로그인을 진행합니다.")
     @PostMapping("/admin-login")

--- a/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
@@ -3,11 +3,14 @@ package com.amcamp.cineAI.domain.member.api;
 import com.amcamp.cineAI.domain.member.application.MemberService;
 import com.amcamp.cineAI.domain.member.dto.request.MemberEditRequest;
 import com.amcamp.cineAI.domain.member.dto.response.MemberInfoResponse;
+import com.amcamp.cineAI.domain.movie.dto.response.BasicMovieInfoResponse;
 import com.amcamp.cineAI.global.util.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -46,5 +49,14 @@ public class MemberController {
             @Valid @RequestBody MemberEditRequest memberEditRequest) {
         memberService.editMemberInfo(memberEditRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/list")
+    public Slice<BasicMovieInfoResponse> memberMovieLikedList(
+            @Parameter(description = "이전 페이지의 마지막 영화 ID (첫 페이지는 비워두세요)")
+                    @RequestParam(required = false)
+                    Long lastMovieId,
+            @RequestParam(value = "size", defaultValue = "3") int pageSize) {
+        return memberService.getMemberLikedMovie(lastMovieId, pageSize);
     }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/member/application/MemberService.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/application/MemberService.java
@@ -45,4 +45,9 @@ public class MemberService {
         currentMember.updateNickname(memberEditRequest.nickname());
         return MemberInfoResponse.of(currentMember);
     }
+
+    //    @Transactional(readOnly = true)
+    //    public Slice<BasicMovieInfoResponse> getMemberLikedMovie(Long lastMovieId, int pageSize) {
+    //
+    //    }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/member/application/MemberService.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/application/MemberService.java
@@ -6,8 +6,11 @@ import com.amcamp.cineAI.domain.member.dao.MemberRepository;
 import com.amcamp.cineAI.domain.member.domain.Member;
 import com.amcamp.cineAI.domain.member.dto.request.MemberEditRequest;
 import com.amcamp.cineAI.domain.member.dto.response.MemberInfoResponse;
+import com.amcamp.cineAI.domain.movie.dao.MoviePreferenceRepository;
+import com.amcamp.cineAI.domain.movie.dto.response.BasicMovieInfoResponse;
 import com.amcamp.cineAI.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +21,7 @@ public class MemberService {
     private final MemberUtil memberUtil;
     private final RefreshTokenRepository refreshTokenRepository;
     private final MemberRepository memberRepository;
+    private final MoviePreferenceRepository moviePreferenceRepository;
 
     public void logoutMember() {
         Member currentMember = memberUtil.getCurrentMember();
@@ -46,8 +50,10 @@ public class MemberService {
         return MemberInfoResponse.of(currentMember);
     }
 
-    //    @Transactional(readOnly = true)
-    //    public Slice<BasicMovieInfoResponse> getMemberLikedMovie(Long lastMovieId, int pageSize) {
-    //
-    //    }
+    @Transactional(readOnly = true)
+    public Slice<BasicMovieInfoResponse> getMemberLikedMovie(Long lastMovieId, int pageSize) {
+        Member currentMember = memberUtil.getCurrentMember();
+        Long memberId = currentMember.getId();
+        return moviePreferenceRepository.findMemberLikedMovie(lastMovieId, pageSize, memberId);
+    }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/movie/MovieConstants.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/MovieConstants.java
@@ -1,0 +1,67 @@
+package com.amcamp.cineAI.domain.movie;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+public class MovieConstants {
+    public static final List<String> MOVIE_LIST =
+            Arrays.asList(
+                    // 드라마
+                    "포레스트 검프",
+                    "기생충",
+                    "버닝",
+
+                    // 액션
+                    "어벤져스: 엔드게임",
+                    "올드보이",
+                    "베를린",
+
+                    // 로맨스
+                    "노트북",
+                    "지금, 만나러 갑니다",
+                    "내 머리 속의 지우개",
+
+                    // 코미디
+                    "슈퍼배드",
+                    "과속스캔들",
+                    "극한직업",
+
+                    // 스릴러
+                    "세븐",
+                    "신세계",
+                    "살인의 추억",
+
+                    // 호러
+                    "더 바이탈",
+                    "곡성",
+                    "여고괴담: 여우계단",
+
+                    // SF
+                    "인셉션",
+                    "승리호",
+
+                    // 애니메이션
+                    "토이 스토리 3",
+                    "마당을 나온 암탉",
+
+                    // 전쟁
+                    "라이언 일병 구하기",
+
+                    // 뮤지컬
+                    "라라랜드");
+
+    public static List<String> getRandomMovies(int size) {
+        List<String> randomMovies = new ArrayList<>();
+        Random random = new Random();
+
+        // 리스트 크기보다 작은 값을 입력하면, 그만큼만 랜덤으로 선택
+        for (int i = 0; i < size; i++) {
+            int randomIndex = random.nextInt(MOVIE_LIST.size()); // 0부터 MOVIE_LIST 크기 - 1까지의 랜덤 인덱스
+            randomMovies.add(MOVIE_LIST.get(randomIndex));
+        }
+
+        return randomMovies;
+    }
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
@@ -44,12 +45,13 @@ public class MovieController {
         return movieService.getMovieInfo(movieId);
     }
 
-    //    @Operation(summary = "초기 설정: 영화 시청 반응 추가 대상 영화 조회", description = "사용자에게 초기 설정을 위한 영화 목록을
-    // 제공합니다")
-    //    @GetMapping ("/init")
-    //    public List<BasicMovieInfoResponse> movieInit (){
-    //        return movieService.getMovieInitInfo();
-    //    }
+    @Operation(
+            summary = "초기 설정: 영화 시청 반응 추가 대상 영화 조회",
+            description = "사용자에게 초기 설정을 위한 영화 목록을 제공합니다")
+    @GetMapping("/init")
+    public List<BasicMovieInfoResponse> movieInit(@RequestParam(required = false) int size) {
+        return movieService.getMovieInitInfo(size);
+    }
 
     @Operation(summary = "관심 있는 영화 반응 업데이트 ", description = "사용자가 관심을 표시한 영화 반응을 업데이트합니다")
     @PatchMapping("/liked")

--- a/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
@@ -49,7 +49,7 @@ public class MovieController {
             summary = "초기 설정: 영화 시청 반응 추가 대상 영화 조회",
             description = "사용자에게 초기 설정을 위한 영화 목록을 제공합니다")
     @GetMapping("/init")
-    public List<BasicMovieInfoResponse> movieInit(@RequestParam(required = false) int size) {
+    public List<BasicMovieInfoResponse> movieInit(@RequestParam(required = true) int size) {
         return movieService.getMovieInitInfo(size);
     }
 

--- a/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
@@ -59,4 +59,14 @@ public class MovieController {
         movieService.updateMovieLikedStatus(movieId);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "관리자 로그인", description = "관리자용 비밀번호를 입력받아 관리자 로그인을 진행합니다.")
+    @PostMapping("/admin-login")
+    public ResponseEntity<String> adminLogin(@RequestParam String password) {
+        if ("admin1234".equals(password)) {
+            return ResponseEntity.ok("로그인 성공");
+        } else {
+            return ResponseEntity.status(401).body("비밀번호가 잘못되었습니다.");
+        }
+    }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
@@ -43,4 +43,18 @@ public class MovieController {
     public MovieInfoResponse movieInfo(@PathVariable Long movieId) {
         return movieService.getMovieInfo(movieId);
     }
+
+    //    @Operation(summary = "초기 설정: 영화 시청 반응 추가 대상 영화 조회", description = "사용자에게 초기 설정을 위한 영화 목록을
+    // 제공합니다")
+    //    @GetMapping ("/init")
+    //    public List<BasicMovieInfoResponse> movieInit (){
+    //        return movieService.getMovieInitInfo();
+    //    }
+
+    @Operation(summary = "관심 있는 영화 반응 업데이트 ", description = "사용자가 관심을 표시한 영화 반응을 업데이트합니다")
+    @PatchMapping("/liked")
+    public ResponseEntity<Void> movieLikedUpdate(@RequestParam(required = true) Long movieId) {
+        movieService.updateMovieLikedStatus(movieId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/api/MovieController.java
@@ -59,14 +59,4 @@ public class MovieController {
         movieService.updateMovieLikedStatus(movieId);
         return ResponseEntity.ok().build();
     }
-
-    @Operation(summary = "관리자 로그인", description = "관리자용 비밀번호를 입력받아 관리자 로그인을 진행합니다.")
-    @PostMapping("/admin-login")
-    public ResponseEntity<String> adminLogin(@RequestParam String password) {
-        if ("admin1234".equals(password)) {
-            return ResponseEntity.ok("로그인 성공");
-        } else {
-            return ResponseEntity.status(401).body("비밀번호가 잘못되었습니다.");
-        }
-    }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/movie/application/MovieService.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/application/MovieService.java
@@ -1,6 +1,7 @@
 package com.amcamp.cineAI.domain.movie.application;
 
 import com.amcamp.cineAI.domain.member.domain.Member;
+import com.amcamp.cineAI.domain.movie.MovieConstants;
 import com.amcamp.cineAI.domain.movie.dao.MoviePreferenceRepository;
 import com.amcamp.cineAI.domain.movie.dao.MovieRepository;
 import com.amcamp.cineAI.domain.movie.domain.Movie;
@@ -12,6 +13,8 @@ import com.amcamp.cineAI.domain.movie.dto.response.MovieInfoResponse;
 import com.amcamp.cineAI.global.error.exception.CustomException;
 import com.amcamp.cineAI.global.error.exception.ErrorCode;
 import com.amcamp.cineAI.global.util.MemberUtil;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -44,11 +47,17 @@ public class MovieService {
         return MovieInfoResponse.of(movie);
     }
 
-    //    @Transactional(readOnly = true)
-    //    public List<BasicMovieInfoResponse> getMovieInitInfo() {
-    //        // 영화 제목 넣어놓고 돌려가면서 movieRepository에서 조회
-    //        // BasicMovieInfoResposne 엮은 리스트로 만들어서 반환
-    //    }
+    @Transactional(readOnly = true)
+    public List<BasicMovieInfoResponse> getMovieInitInfo(int size) {
+        List<String> movieTitleList = MovieConstants.getRandomMovies(size);
+        List<Movie> movieList = getMoviesByTitles(movieTitleList);
+        List<BasicMovieInfoResponse> result = new ArrayList<>();
+        for (Movie movie : movieList) {
+            result.add(BasicMovieInfoResponse.of(movie));
+        }
+        return result;
+    }
+
     public void updateMovieLikedStatus(Long movieId) {
         Movie movie =
                 movieRepository
@@ -65,5 +74,16 @@ public class MovieService {
             moviePreferenceRepository.save(
                     MoviePreference.createMoviePreference(member, movie, MovieLikedStatus.LIKED));
         }
+    }
+
+    private List<Movie> getMoviesByTitles(List<String> movieTitles) {
+        List<Movie> movies = new ArrayList<>();
+        for (String title : movieTitles) {
+            Movie movie = movieRepository.findByTitle(title);
+            if (movie != null) {
+                movies.add(movie);
+            }
+        }
+        return movies;
     }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/movie/application/MovieService.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/application/MovieService.java
@@ -1,12 +1,17 @@
 package com.amcamp.cineAI.domain.movie.application;
 
+import com.amcamp.cineAI.domain.member.domain.Member;
+import com.amcamp.cineAI.domain.movie.dao.MoviePreferenceRepository;
 import com.amcamp.cineAI.domain.movie.dao.MovieRepository;
 import com.amcamp.cineAI.domain.movie.domain.Movie;
+import com.amcamp.cineAI.domain.movie.domain.MovieLikedStatus;
+import com.amcamp.cineAI.domain.movie.domain.MoviePreference;
 import com.amcamp.cineAI.domain.movie.dto.request.NewMovieCreateRequest;
 import com.amcamp.cineAI.domain.movie.dto.response.BasicMovieInfoResponse;
 import com.amcamp.cineAI.domain.movie.dto.response.MovieInfoResponse;
 import com.amcamp.cineAI.global.error.exception.CustomException;
 import com.amcamp.cineAI.global.error.exception.ErrorCode;
+import com.amcamp.cineAI.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -17,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MovieService {
     private final MovieRepository movieRepository;
+    private final MoviePreferenceRepository moviePreferenceRepository;
+    private final MemberUtil memberUtil;
 
     public void createMovie(NewMovieCreateRequest request) {
         Movie newMovie = Movie.createMovie(request);
@@ -35,5 +42,28 @@ public class MovieService {
                         .findById(movieId)
                         .orElseThrow(() -> new CustomException(ErrorCode.MOVIE_NOT_FOUND)); // 예외 던짐
         return MovieInfoResponse.of(movie);
+    }
+
+    //    @Transactional(readOnly = true)
+    //    public List<BasicMovieInfoResponse> getMovieInitInfo() {
+    //        // 영화 제목 넣어놓고 돌려가면서 movieRepository에서 조회
+    //        // BasicMovieInfoResposne 엮은 리스트로 만들어서 반환
+    //    }
+    public void updateMovieLikedStatus(Long movieId) {
+        Movie movie =
+                movieRepository
+                        .findById(movieId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.MOVIE_NOT_FOUND));
+        Member member = memberUtil.getCurrentMember();
+
+        MoviePreference moviePreference =
+                moviePreferenceRepository.findByMovieAndMember(movie.getId(), member.getId());
+
+        if (moviePreference != null) {
+            moviePreference.updateLikedStatus();
+        } else {
+            moviePreferenceRepository.save(
+                    MoviePreference.createMoviePreference(member, movie, MovieLikedStatus.LIKED));
+        }
     }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/movie/application/MovieService.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/application/MovieService.java
@@ -14,7 +14,9 @@ import com.amcamp.cineAI.global.error.exception.CustomException;
 import com.amcamp.cineAI.global.error.exception.ErrorCode;
 import com.amcamp.cineAI.global.util.MemberUtil;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -66,7 +68,7 @@ public class MovieService {
         Member member = memberUtil.getCurrentMember();
 
         MoviePreference moviePreference =
-                moviePreferenceRepository.findByMovieAndMember(movie.getId(), member.getId());
+                moviePreferenceRepository.findByMovieIdAndMemberId(movie.getId(), member.getId());
 
         if (moviePreference != null) {
             moviePreference.updateLikedStatus();
@@ -77,12 +79,19 @@ public class MovieService {
     }
 
     private List<Movie> getMoviesByTitles(List<String> movieTitles) {
+        Set<String> seenTitles = new HashSet<>();
         List<Movie> movies = new ArrayList<>();
         for (String title : movieTitles) {
-            Movie movie = movieRepository.findByTitle(title);
-            if (movie != null) {
-                movies.add(movie);
+            if (seenTitles.contains(title)) {
+                continue;
             }
+            Movie movie = movieRepository.findByTitle(title);
+            if (movie == null) {
+                movie = Movie.createMovie(title);
+                movieRepository.save(movie);
+            }
+            movies.add(movie);
+            seenTitles.add(title);
         }
         return movies;
     }

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepository.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepository.java
@@ -1,0 +1,8 @@
+package com.amcamp.cineAI.domain.movie.dao;
+
+import com.amcamp.cineAI.domain.movie.domain.MoviePreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MoviePreferenceRepository extends JpaRepository<MoviePreference, Long> {
+    MoviePreference findByMovieAndMember(Long movieId, Long memberId);
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepository.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepository.java
@@ -3,6 +3,7 @@ package com.amcamp.cineAI.domain.movie.dao;
 import com.amcamp.cineAI.domain.movie.domain.MoviePreference;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MoviePreferenceRepository extends JpaRepository<MoviePreference, Long> {
+public interface MoviePreferenceRepository
+        extends JpaRepository<MoviePreference, Long>, MoviePreferenceRepositoryCustom {
     MoviePreference findByMovieAndMember(Long movieId, Long memberId);
 }

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepository.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MoviePreferenceRepository
         extends JpaRepository<MoviePreference, Long>, MoviePreferenceRepositoryCustom {
-    MoviePreference findByMovieAndMember(Long movieId, Long memberId);
+    MoviePreference findByMovieIdAndMemberId(Long movieId, Long memberId);
 }

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepositoryCustom.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.amcamp.cineAI.domain.movie.dao;
+
+import com.amcamp.cineAI.domain.movie.dto.response.BasicMovieInfoResponse;
+import org.springframework.data.domain.Slice;
+
+public interface MoviePreferenceRepositoryCustom {
+    Slice<BasicMovieInfoResponse> findMemberLikedMovie(
+            Long lastMovieId, int pageSize, Long memberId);
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepositoryImpl.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepositoryImpl.java
@@ -29,6 +29,7 @@ public class MoviePreferenceRepositoryImpl implements MoviePreferenceRepositoryC
                         .select(
                                 Projections.constructor(
                                         BasicMovieInfoResponse.class,
+                                        movie.id,
                                         movie.title,
                                         movie.posterImageUrl,
                                         movie.genreList,

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepositoryImpl.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dao/MoviePreferenceRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.amcamp.cineAI.domain.movie.dao;
+
+import static com.amcamp.cineAI.domain.movie.domain.QMovie.movie;
+import static com.amcamp.cineAI.domain.movie.domain.QMoviePreference.moviePreference;
+
+import com.amcamp.cineAI.domain.movie.domain.MovieLikedStatus;
+import com.amcamp.cineAI.domain.movie.dto.response.BasicMovieInfoResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MoviePreferenceRepositoryImpl implements MoviePreferenceRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Slice<BasicMovieInfoResponse> findMemberLikedMovie(
+            Long lastMovieId, int pageSize, Long memberId) {
+        List<BasicMovieInfoResponse> results =
+                jpaQueryFactory
+                        .select(
+                                Projections.constructor(
+                                        BasicMovieInfoResponse.class,
+                                        movie.title,
+                                        movie.posterImageUrl,
+                                        movie.genreList,
+                                        movie.releaseYear))
+                        .from(moviePreference)
+                        .join(moviePreference.movie, movie)
+                        .where(
+                                moviePreference.member.id.eq(memberId),
+                                moviePreference.liked.eq(MovieLikedStatus.LIKED))
+                        .limit(pageSize + 1) // 페이지 사이즈 + 1개 더 가져와서 마지막 페이지 확인
+                        .fetch();
+
+        return checkLastPage(pageSize, results);
+    }
+
+    private BooleanExpression lastMemberId(Long movieId) {
+        if (movieId == null) {
+            return null;
+        }
+
+        return movie.id.lt(movieId);
+    }
+
+    private Slice<BasicMovieInfoResponse> checkLastPage(
+            int pageSize, List<BasicMovieInfoResponse> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+    }
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dao/MovieRepository.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dao/MovieRepository.java
@@ -3,4 +3,6 @@ package com.amcamp.cineAI.domain.movie.dao;
 import com.amcamp.cineAI.domain.movie.domain.Movie;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MovieRepository extends JpaRepository<Movie, Long>, MovieRepositoryCustom {}
+public interface MovieRepository extends JpaRepository<Movie, Long>, MovieRepositoryCustom {
+    Movie findByTitle(String title);
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dao/MovieRepositoryImpl.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dao/MovieRepositoryImpl.java
@@ -26,6 +26,7 @@ public class MovieRepositoryImpl implements MovieRepositoryCustom {
                         .select(
                                 Projections.constructor(
                                         BasicMovieInfoResponse.class,
+                                        movie.id,
                                         movie.title,
                                         movie.posterImageUrl,
                                         movie.genreList,

--- a/src/main/java/com/amcamp/cineAI/domain/movie/domain/Movie.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/domain/Movie.java
@@ -68,4 +68,15 @@ public class Movie extends BaseTimeEntity {
                 .status(MovieStatus.CREATED)
                 .build();
     }
+
+    public static Movie createMovie(String title) {
+        return Movie.builder()
+                .title(title)
+                .posterImageUrl("example.com")
+                .directorName("example name")
+                .nation("KR")
+                .plot("Plot")
+                .status(MovieStatus.CREATED)
+                .build();
+    }
 }

--- a/src/main/java/com/amcamp/cineAI/domain/movie/domain/Movie.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/domain/Movie.java
@@ -3,6 +3,7 @@ package com.amcamp.cineAI.domain.movie.domain;
 import com.amcamp.cineAI.domain.common.model.BaseTimeEntity;
 import com.amcamp.cineAI.domain.movie.dto.request.NewMovieCreateRequest;
 import jakarta.persistence.*;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,10 +21,10 @@ public class Movie extends BaseTimeEntity {
     private String title;
     private String posterImageUrl;
     private String directorName;
-    private String[] castsList;
+    private List<String> castsList;
     private String nation;
     private String plot;
-    private String[] genreList;
+    private List<String> genreList;
     private Long accAudiences;
     private String releaseYear;
 
@@ -36,9 +37,9 @@ public class Movie extends BaseTimeEntity {
             String posterImageUrl,
             String directorName,
             String nation,
-            String[] castList,
+            List<String> castList,
             String plot,
-            String[] genreList,
+            List<String> genreList,
             Long accAudiences,
             String releaseYear,
             MovieStatus status) {

--- a/src/main/java/com/amcamp/cineAI/domain/movie/domain/MovieLikedStatus.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/domain/MovieLikedStatus.java
@@ -1,0 +1,13 @@
+package com.amcamp.cineAI.domain.movie.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MovieLikedStatus {
+    LIKED("MOVIE_LIKED"),
+    DISLIKED("MOVIE_DISLIKED"),
+    ;
+    private final String liked;
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/domain/MoviePreference.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/domain/MoviePreference.java
@@ -1,0 +1,50 @@
+package com.amcamp.cineAI.domain.movie.domain;
+
+import com.amcamp.cineAI.domain.common.model.BaseTimeEntity;
+import com.amcamp.cineAI.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MoviePreference extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "movie_preference_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "movie_id")
+    private Movie movie;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private MovieLikedStatus liked;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private MoviePreference(Member member, Movie movie, MovieLikedStatus liked) {
+        this.member = member;
+        this.movie = movie;
+        this.liked = liked;
+    }
+
+    public static MoviePreference createMoviePreference(
+            Member member, Movie movie, MovieLikedStatus liked) {
+        return MoviePreference.builder().member(member).movie(movie).liked(liked).build();
+    }
+
+    public void updateLikedStatus() {
+        if (this.liked == MovieLikedStatus.LIKED) {
+            this.liked = MovieLikedStatus.DISLIKED;
+        } else {
+            this.liked = MovieLikedStatus.LIKED;
+        }
+    }
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dto/request/NewMovieCreateRequest.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dto/request/NewMovieCreateRequest.java
@@ -1,12 +1,14 @@
 package com.amcamp.cineAI.domain.movie.dto.request;
 
+import java.util.List;
+
 public record NewMovieCreateRequest(
         String title,
         String posterImageUrl,
         String directorName,
-        String[] castList,
+        List<String> castList,
         String nation,
         String plot,
-        String[] genreList,
+        List<String> genreList,
         Long accAudiences,
         String releaseYear) {}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dto/response/BasicMovieInfoResponse.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dto/response/BasicMovieInfoResponse.java
@@ -1,4 +1,15 @@
 package com.amcamp.cineAI.domain.movie.dto.response;
 
+import com.amcamp.cineAI.domain.movie.domain.Movie;
+
 public record BasicMovieInfoResponse(
-        String title, String posterImageUrl, String[] genreList, String releaseYear) {}
+        Long movieId, String title, String posterImageUrl, String[] genreList, String releaseYear) {
+    public static BasicMovieInfoResponse of(Movie movie) {
+        return new BasicMovieInfoResponse(
+                movie.getId(),
+                movie.getTitle(),
+                movie.getPosterImageUrl(),
+                movie.getGenreList(),
+                movie.getReleaseYear());
+    }
+}

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dto/response/BasicMovieInfoResponse.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dto/response/BasicMovieInfoResponse.java
@@ -1,9 +1,14 @@
 package com.amcamp.cineAI.domain.movie.dto.response;
 
 import com.amcamp.cineAI.domain.movie.domain.Movie;
+import java.util.List;
 
 public record BasicMovieInfoResponse(
-        Long movieId, String title, String posterImageUrl, String[] genreList, String releaseYear) {
+        Long movieId,
+        String title,
+        String posterImageUrl,
+        List<String> genreList,
+        String releaseYear) {
     public static BasicMovieInfoResponse of(Movie movie) {
         return new BasicMovieInfoResponse(
                 movie.getId(),

--- a/src/main/java/com/amcamp/cineAI/domain/movie/dto/response/MovieInfoResponse.java
+++ b/src/main/java/com/amcamp/cineAI/domain/movie/dto/response/MovieInfoResponse.java
@@ -1,16 +1,17 @@
 package com.amcamp.cineAI.domain.movie.dto.response;
 
 import com.amcamp.cineAI.domain.movie.domain.Movie;
+import java.util.List;
 
 public record MovieInfoResponse(
         Long id,
         String title,
         String posterImageUrl,
         String directorName,
-        String[] castsList,
+        List<String> castsList,
         String nation,
         String plot,
-        String[] genreList,
+        List<String> genreList,
         Long accAudiences,
         String releaseYear) {
     public static MovieInfoResponse of(Movie movie) {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #29 

---
## 📌 작업 내용 및 특이사항

- 초기 영화 취향 업데이트를 위한 영화 목록 조회 기능을 구현했습니다. 장르별 영화 상수를 바탕으로 값을 반환합니다. 
- 영화 취향을 업데이트하는 기능을 구현했습니다. 호출 시 MoviePreference에 취향이 업데이트됩니다.
- 회원이 좋아하는 영화를 모아볼 수 있는 기능을 구현했습니다. MoviePreference에서 회원아이디와 Status를 조회한 후 해당하는 영화를 반환합니다. 

---
## 📚 참고사항

-
