### PR TITLE
fix: 쿠키 전송 오류 수정

### DIFF
--- a/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
+++ b/src/main/java/com/amcamp/cineAI/domain/member/api/MemberController.java
@@ -68,6 +68,5 @@ public class MemberController {
         } else {
             return ResponseEntity.status(401).body("비밀번호가 잘못되었습니다.");
         }
-
     }
 }

--- a/src/main/java/com/amcamp/cineAI/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/amcamp/cineAI/global/config/security/WebSecurityConfig.java
@@ -42,6 +42,7 @@ public class WebSecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
+        configuration.addAllowedOrigin("http://localhost:5173"); // 허용할 프론트엔드 주소
         configuration.addAllowedHeader("*"); // 모든 헤더를 허용
         configuration.addAllowedMethod("*"); // 모든 HTTP 메서드를 허용 (GET, POST 등)
         configuration.setAllowCredentials(true); // 자격 증명(쿠키 등)을 허용

--- a/src/main/java/com/amcamp/cineAI/global/util/CookieUtil.java
+++ b/src/main/java/com/amcamp/cineAI/global/util/CookieUtil.java
@@ -18,7 +18,7 @@ public class CookieUtil {
                 ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
                         .path("/")
                         .secure(false)
-                        .sameSite(Cookie.SameSite.NONE.attributeValue()) // https only none
+                        .sameSite(Cookie.SameSite.STRICT.attributeValue())
                         .httpOnly(true) // js에서 접근 금지
                         .build();
 

--- a/src/main/java/com/amcamp/cineAI/global/util/CookieUtil.java
+++ b/src/main/java/com/amcamp/cineAI/global/util/CookieUtil.java
@@ -18,7 +18,7 @@ public class CookieUtil {
                 ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
                         .path("/")
                         .secure(false)
-                        .sameSite(Cookie.SameSite.STRICT.attributeValue())
+                        .sameSite(Cookie.SameSite.LAX.attributeValue())
                         .httpOnly(true) // js에서 접근 금지
                         .build();
 

--- a/src/main/java/com/amcamp/cineAI/global/util/MemberUtil.java
+++ b/src/main/java/com/amcamp/cineAI/global/util/MemberUtil.java
@@ -28,7 +28,12 @@ public class MemberUtil {
     }
 
     private Long getCurrentMemberId() {
+
         String token = cookieUtil.getRefreshTokenFromCookie();
+
+        if (token == null) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
         Long currentMemberId = refreshTokenRepository.findByToken(token).getMemberId();
         return currentMemberId;
     }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #35 

---
## 📌 작업 내용 및 특이사항

- BE에서 FE로 쿠키 전송 시 FE에서는 쿠키가 잘 전달받지만 FE에서 BE로 전송할때는 쿠키값이 사라지는 오류가 발생했습니다.
- 이는 CookieUtil에서 refreshToken을 만들어 전달할때 Samesite 설정을 Lax가 아닌 None을 사용했기 때문입니다.

---
## 📚 참고사항

- https://velog.io/@wiostz98kr/다른-도메인간-쿠키-전송하기
